### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ An example of a valid OIS can be found [here](https://github.com/api3dao/ois/blo
 
 To release a new version follow these steps:
 
-```sh
-yarn && yarn build
-yarn version # and choose the version to be released
-yarn publish --access public
-git push --follow-tags
-```
+1. `git checkout main && git pull` - ensure you are on a "main" branch with latest changes
+2. `yarn version` - choose "x.y.z" as the version to be released
+3. `yarn build` - only build the package after the "yarn version" command so the bundled "package.json" uses the updated
+   version
+4. `yarn publish --access public`
+5. `git push --follow-tags` - to push the commits to a "main" branch

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To release a new version follow these steps:
 
 1. `git checkout main && git pull` - ensure you are on a "main" branch with latest changes
 2. `yarn version` - choose "x.y.z" as the version to be released
-3. `yarn build` - only build the package after the "yarn version" command so the bundled "package.json" uses the updated
+3. `git show` - verify the changes of the version commit
+4. `yarn build` - only build the package after the "yarn version" command so the bundled "package.json" uses the updated
    version
-4. `yarn publish --access public`
-5. `git push --follow-tags` - to push the commits to a "main" branch
+5. `yarn publish --access public`
+6. `git push --follow-tags` - to push the commits to a "main" branch

--- a/dev-scripts/tsconfig.json
+++ b/dev-scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true,
+
+    // Some rules are too restrictive for test files and make mocking more complex
+    "noUncheckedIndexedAccess": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "references": [{ "path": "../src" }],
+  "include": ["./**/*.ts"]
+}

--- a/dev-scripts/update-fixtures.ts
+++ b/dev-scripts/update-fixtures.ts
@@ -1,0 +1,11 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { version as packageVersion } from '../package.json';
+
+const oisPath = join(__dirname, '../test/fixtures/ois.json');
+const ois = JSON.parse(readFileSync(oisPath, 'utf-8'));
+ois.oisFormat = packageVersion;
+
+writeFileSync(oisPath, JSON.stringify(ois, null, 2) + '\n');
+
+console.log(`Updated ${oisPath}`);

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "lint:tsc": "yarn compile",
     "lint": "yarn lint:prettier && yarn lint:tsc",
     "prepare": "husky install",
+    "version": "yarn update-fixtures && yarn test && git add --all",
     "test:watch": "jest --watch",
-    "test": "jest"
+    "test": "jest",
+    "update-fixtures": "ts-node --transpileOnly ./dev-scripts/update-fixtures.ts"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",

--- a/src/ois.test.ts
+++ b/src/ois.test.ts
@@ -11,6 +11,7 @@ import {
   semverSchema,
   reservedParameterSchema,
 } from './ois';
+import { version as packageVersion } from '../package.json';
 
 const loadOisFixture = (): OIS =>
   // This OIS is guaranteed to be valid because there is a test for it's validity below
@@ -487,9 +488,9 @@ it('validates oisFormat field', () => {
     new ZodError([
       {
         code: 'invalid_literal',
-        expected: '1.0.0',
+        expected: packageVersion,
         path: ['oisFormat'],
-        message: 'Invalid literal value, expected "1.0.0"',
+        message: `Invalid literal value, expected "${packageVersion}"`,
       },
     ])
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     "skipLibCheck": true
   },
   "files": [],
-  "references": [{ "path": "./src" }, { "path": "./test" }]
+  "references": [{ "path": "./src" }, { "path": "./test" }, { "path": "./dev-scripts" }]
 }


### PR DESCRIPTION
The release instructions are wrong and the package is not published correctly because of incorrect release instructions. I've added also script which updates the fixtures before the version commit so when the commit is pushed it will pass tests on CI.

See: https://docs.npmjs.com/cli/v8/commands/npm-version#description

Closes https://github.com/api3dao/ois/issues/6