### PR TITLE
Add optional endpoint flag for API response caching

### DIFF
--- a/src/ois.test.ts
+++ b/src/ois.test.ts
@@ -10,6 +10,8 @@ import {
   pathNameSchema,
   semverSchema,
   reservedParameterSchema,
+  stringifiedBooleanSchema,
+  endpointSchema,
 } from './ois';
 import { version as packageVersion } from '../package.json';
 
@@ -494,4 +496,12 @@ it('validates oisFormat field', () => {
       },
     ])
   );
+});
+
+it('correctly parses stringified booleans', () => {
+  const strFalse = 'false';
+  const strTrue = 'true';
+
+  expect(stringifiedBooleanSchema.parse(strFalse)).toEqual(false);
+  expect(stringifiedBooleanSchema.parse(strTrue)).toEqual(true);
 });

--- a/src/ois.ts
+++ b/src/ois.ts
@@ -269,6 +269,8 @@ const ensureUniqueEndpointParameterNames: SuperRefinement<EndpointParameter[]> =
 
 const endpointParametersSchema = z.array(endpointParameterSchema).superRefine(ensureUniqueEndpointParameterNames);
 
+export const stringifiedBooleanSchema = z.string().transform((val) => val === 'true');
+
 export const endpointSchema = z
   .object({
     fixedOperationParameters: z.array(fixedParameterSchema),
@@ -276,6 +278,7 @@ export const endpointSchema = z
     operation: endpointOperationSchema,
     parameters: endpointParametersSchema,
     reservedParameters: z.array(reservedParameterSchema),
+    cacheResponses: stringifiedBooleanSchema.optional(),
 
     // Processing is and advanced use case that needs to be used with special care. For this reason,
     // we are defining the processing specification as optional fields.

--- a/test/fixtures/ois.json
+++ b/test/fixtures/ois.json
@@ -52,6 +52,7 @@
         "method": "get",
         "path": "/convert"
       },
+      "cacheResponses": "false",
       "fixedOperationParameters": [
         {
           "operationParameter": {


### PR DESCRIPTION
Part of api3dao/airnode#1190.

Assumes the boolean flag will be stringified like the other parameters e.g. `"false"` and therefore adds a `transform` for parsing it into a boolean.