### PR TITLE
Fix docs CI latest version replacement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Update latest paths
         run: |
           wget https://raw.githubusercontent.com/api3dao/api3-docs/main/docs/.vuepress/config.js
-          for i in latestVersion latestBeaconVersion latestOisVersion; do
-            path=$(grep $i config.js | cut -d\' -f2);
+          for i in latestVersion latestOisVersion; do
+            path=$(grep $i: config.js | cut -d\' -f2);
             echo "Renaming: $i --> $path";
             sed -i "s@$i@$path@" .github/workflows/mlc_config.json;
           done


### PR DESCRIPTION
1. Changes grep to avoid multiple results like in the last failed run (https://github.com/api3dao/ois/runs/7518879094?check_suite_focus=true)
2. Deletes the latest beacon version replacement as it's no longer present in the docs