### PR TITLE
Revert "Add optional endpoint flag for API response caching"

### DIFF
--- a/src/ois.test.ts
+++ b/src/ois.test.ts
@@ -10,8 +10,6 @@ import {
   pathNameSchema,
   semverSchema,
   reservedParameterSchema,
-  stringifiedBooleanSchema,
-  endpointSchema,
 } from './ois';
 import { version as packageVersion } from '../package.json';
 
@@ -496,12 +494,4 @@ it('validates oisFormat field', () => {
       },
     ])
   );
-});
-
-it('correctly parses stringified booleans', () => {
-  const strFalse = 'false';
-  const strTrue = 'true';
-
-  expect(stringifiedBooleanSchema.parse(strFalse)).toEqual(false);
-  expect(stringifiedBooleanSchema.parse(strTrue)).toEqual(true);
 });

--- a/src/ois.ts
+++ b/src/ois.ts
@@ -269,8 +269,6 @@ const ensureUniqueEndpointParameterNames: SuperRefinement<EndpointParameter[]> =
 
 const endpointParametersSchema = z.array(endpointParameterSchema).superRefine(ensureUniqueEndpointParameterNames);
 
-export const stringifiedBooleanSchema = z.string().transform((val) => val === 'true');
-
 export const endpointSchema = z
   .object({
     fixedOperationParameters: z.array(fixedParameterSchema),
@@ -278,7 +276,6 @@ export const endpointSchema = z
     operation: endpointOperationSchema,
     parameters: endpointParametersSchema,
     reservedParameters: z.array(reservedParameterSchema),
-    cacheResponses: stringifiedBooleanSchema.optional(),
 
     // Processing is and advanced use case that needs to be used with special care. For this reason,
     // we are defining the processing specification as optional fields.

--- a/test/fixtures/ois.json
+++ b/test/fixtures/ois.json
@@ -52,7 +52,6 @@
         "method": "get",
         "path": "/convert"
       },
-      "cacheResponses": "false",
       "fixedOperationParameters": [
         {
           "operationParameter": {


### PR DESCRIPTION
Reverts api3dao/ois#16 as it was decided that this flag should instead live in `triggers.rrp[n]` of `config.json`. For some discussion see: https://github.com/api3dao/airnode/pull/1372#discussion_r942044155