### PR TITLE
feat: add _gasPrice reserved parameter

### DIFF
--- a/src/ois.test.ts
+++ b/src/ois.test.ts
@@ -558,29 +558,31 @@ describe('reservedParameter validation', () => {
     expect(() => reservedParametersSchema.parse([{ name: '_type', fixed: 'int256' }])).not.toThrow();
   });
 
-  it('allows missing value or non-negative integer strings for _minConfirmations', () => {
-    const validIntStrDefault = { name: '_minConfirmations', default: '3' };
-    const validIntStrFixed = { name: '_minConfirmations', fixed: '3' };
-    // If default and fixed are absent, the user (requester) is expected to pass the value as parameter
-    const validMissing = { name: '_minConfirmations' };
-    const invalidNotInt = { name: '_minConfirmations', default: 'text' };
-    const invalidNegativeInt = { name: '_minConfirmations', default: '-5' };
+  ['_minConfirmations', '_gasPrice'].forEach((reservedParam) => {
+    it(`allows missing value or non-negative integer strings for ${reservedParam}`, () => {
+      const validIntStrDefault = { name: reservedParam, default: '3' };
+      const validIntStrFixed = { name: reservedParam, fixed: '3' };
+      // If default and fixed are absent, the user (requester) is expected to pass the value as parameter
+      const validMissing = { name: reservedParam };
+      const invalidNotInt = { name: reservedParam, default: 'text' };
+      const invalidNegativeInt = { name: reservedParam, default: '-5' };
 
-    [validIntStrDefault, validIntStrFixed, validMissing].forEach((obj) =>
-      expect(() => reservedParameterSchema.parse(obj)).not.toThrow()
-    );
+      [validIntStrDefault, validIntStrFixed, validMissing].forEach((obj) =>
+        expect(() => reservedParameterSchema.parse(obj)).not.toThrow()
+      );
 
-    [invalidNotInt, invalidNegativeInt].forEach((obj) =>
-      expect(() => reservedParameterSchema.parse(obj)).toThrow(
-        new ZodError([
-          {
-            code: 'custom',
-            message: 'Reserved parameter _minConfirmations must be a non-negative integer if present',
-            path: [],
-          },
-        ])
-      )
-    );
+      [invalidNotInt, invalidNegativeInt].forEach((obj) =>
+        expect(() => reservedParameterSchema.parse(obj)).toThrow(
+          new ZodError([
+            {
+              code: 'custom',
+              message: `Reserved parameter ${reservedParam} must be a non-negative integer if present`,
+              path: [],
+            },
+          ])
+        )
+      );
+    });
   });
 });
 

--- a/src/ois.ts
+++ b/src/ois.ts
@@ -74,6 +74,7 @@ export const reservedParameterNameSchema = z.union([
   z.literal('_path'),
   z.literal('_times'),
   z.literal('_minConfirmations'),
+  z.literal('_gasPrice'),
 ]);
 
 export const reservedParameterSchema = z
@@ -97,12 +98,17 @@ export const reservedParameterSchema = z
   .superRefine((param, ctx) => {
     // Default or fixed, or neither, may be present as validated by refine above
     const val = param.default ? param.default : param.fixed;
+    const name = param.name;
 
-    // Validate a value if present
-    if (param.name === '_minConfirmations' && val && !nonNegativeIntSchema.safeParse(parseInt(val)).success) {
+    // Validate value if present
+    if (
+      (name === '_minConfirmations' || name === '_gasPrice') &&
+      val &&
+      !nonNegativeIntSchema.safeParse(parseInt(val)).success
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Reserved parameter _minConfirmations must be a non-negative integer if present',
+        message: `Reserved parameter ${name} must be a non-negative integer if present`,
       });
     }
   });

--- a/test/fixtures/ois.json
+++ b/test/fixtures/ois.json
@@ -75,8 +75,10 @@
           "default": "1000000"
         },
         {
-          "name": "_minConfirmations",
-          "default": "6"
+          "name": "_minConfirmations"
+        },
+        {
+          "name": "_gasPrice"
         }
       ],
       "parameters": [


### PR DESCRIPTION
Closes #50. Builds off of the validation implemented in #52 given `_gasPrice` and `_minConfirmations` are both new reserved parameters with the same type.