### PR TITLE
fix: link to docs and docs CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,6 @@ jobs:
     steps:
       - name: Clone @api3/ois
         uses: actions/checkout@master
-      - name: Update latest paths
-        run: |
-          wget https://raw.githubusercontent.com/api3dao/api3-docs/main/docs/.vuepress/config.js
-          for i in latestVersion latestOisVersion; do
-            path=$(grep $i: config.js | cut -d\' -f2);
-            echo "Renaming: $i --> $path";
-            sed -i "s@$i@$path@" .github/workflows/mlc_config.json;
-          done
       - name: Check hyperlinks
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,18 +1,5 @@
 {
-  "replacementPatterns": [
-    {
-      "pattern": "/airnode/latest/",
-      "replacement": "latestVersion"
-    },
-    {
-      "pattern": "/beacon/latest/",
-      "replacement": "latestBeaconVersion"
-    },
-    {
-      "pattern": "/ois/latest/",
-      "replacement": "latestOisVersion"
-    }
-  ],
+  "replacementPatterns": [],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "10s"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > OIS (or Oracle Integration Specifications) is a JSON object that describes an API specification
 
-You can find the documentation for OIS in the [docs](https://docs.api3.org/ois/latest/).
+You can find the documentation for OIS in the [docs](https://docs.api3.org/reference/ois/latest/).
 
 ## Installation
 


### PR DESCRIPTION
Updates a docs link and fixes failing docs CI using the same changes as in https://github.com/api3dao/airnode/pull/1731