### PR TITLE
Skip API call with processing v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 # IDE specific files
 .idea
 .vscode
+.DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,5 +7,7 @@
 # Test files
 coverage/
 
-# Jetbrains
+# IDE specific files
 .idea
+.vscode
+.DS_Store

--- a/src/ois.test.ts
+++ b/src/ois.test.ts
@@ -609,7 +609,7 @@ describe('API call skip validation', () => {
       new ZodError([
         {
           code: 'custom',
-          message: `"postProcessingSpecifications" or "preProcessingSpecifications" must not be empty or undefined when "operation" is not specified and "fixedOperationParameters" is empty array.`,
+          message: `At least one processing schema must be defined when "operation" is not specified and "fixedOperationParameters" is empty array.`,
           path: ['endpoints', 0],
         },
       ])
@@ -626,7 +626,7 @@ describe('API call skip validation', () => {
       new ZodError([
         {
           code: 'custom',
-          message: `"postProcessingSpecifications" or "preProcessingSpecifications" must not be empty or undefined when "operation" is not specified and "fixedOperationParameters" is empty array.`,
+          message: `At least one processing schema must be defined when "operation" is not specified and "fixedOperationParameters" is empty array.`,
           path: ['endpoints', 0],
         },
       ])

--- a/src/ois.test.ts
+++ b/src/ois.test.ts
@@ -706,6 +706,32 @@ describe('API call skip validation', () => {
       ])
     );
   });
+
+  it('allows skipping API call with pre-processing v2', () => {
+    const ois = loadOisFixture();
+    ois.endpoints[0].operation = undefined;
+    ois.endpoints[0].fixedOperationParameters = [];
+    ois.endpoints[0].preProcessingSpecificationV2 = {
+      environment: 'Node',
+      timeoutMs: 5000,
+      value: 'output = input;',
+    };
+
+    expect(() => oisSchema.parse(ois)).not.toThrow();
+  });
+
+  it('allows skipping API call with post-processing v2', () => {
+    const ois = loadOisFixture();
+    ois.endpoints[0].operation = undefined;
+    ois.endpoints[0].fixedOperationParameters = [];
+    ois.endpoints[0].postProcessingSpecificationV2 = {
+      environment: 'Node',
+      timeoutMs: 5000,
+      value: 'output = input;',
+    };
+
+    expect(() => oisSchema.parse(ois)).not.toThrow();
+  });
 });
 
 describe('fixedOperationParameters', () => {

--- a/src/ois.ts
+++ b/src/ois.ts
@@ -423,11 +423,13 @@ const ensureApiCallSkipRequirements: SuperRefinement<{
       !endpoint.operation &&
       endpoint.fixedOperationParameters.length === 0 &&
       (!endpoint.postProcessingSpecifications || endpoint.postProcessingSpecifications?.length === 0) &&
-      (!endpoint.preProcessingSpecifications || endpoint.preProcessingSpecifications?.length === 0)
+      (!endpoint.preProcessingSpecifications || endpoint.preProcessingSpecifications?.length === 0) &&
+      !endpoint.preProcessingSpecificationV2 &&
+      !endpoint.postProcessingSpecificationV2
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `"postProcessingSpecifications" or "preProcessingSpecifications" must not be empty or undefined when "operation" is not specified and "fixedOperationParameters" is empty array.`,
+        message: `At least one processing schema must be defined when "operation" is not specified and "fixedOperationParameters" is empty array.`,
         path: ['endpoints', endpoints.indexOf(endpoint)],
       });
     }


### PR DESCRIPTION
Closes https://github.com/api3dao/ois/issues/129

After the issue is merged we should release a patch version for OIS and do a migration in Airnode and Airnode feed. This shouldn't be a blocker, because you can use the legacy processing for the time being.